### PR TITLE
Limpando o arquivo .npmrc

### DIFF
--- a/.github/workflows/publish-lib.yml
+++ b/.github/workflows/publish-lib.yml
@@ -43,12 +43,12 @@ jobs:
         GITHUB_PACKAGES_TOKEN: ${{ steps.GITHUB_PACKAGES_TOKEN.outputs.token_github }}
         NPM_TOKEN: ${{ steps.NPM_TOKEN.outputs.token_npm }}
         PACKAGES_NPMRC: ${{ steps.PACKAGES_NPMRC.outputs.token_npmrc }}
-  publish:
-    name: Publish
+  build:
+    name: Build
     runs-on: ubuntu-latest
     needs: [check-secret]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
           node-version: '18.x'
@@ -60,6 +60,12 @@ jobs:
           PACKAGES_NPMRC: ${{ secrets.PACKAGES_NPMRC }}
       - name: Install and Build
         run: yarn install && yarn build
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clean .npmrc
+        run: echo > .npmrc
       - if: inputs.PROJECT_PRIVATE != 'true'
         name: Publish NPM Public
         run: npm publish --access public
@@ -70,6 +76,11 @@ jobs:
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
       - uses: actions/setup-node@v2
         with:
           node-version: '18.x'

--- a/.github/workflows/publish-lib.yml
+++ b/.github/workflows/publish-lib.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check-secret]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: '18.x'
@@ -80,7 +80,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: '18.x'


### PR DESCRIPTION
Adicionado comando para limpar o .npmrc antes de publicar, o arquivo estava sendo preenchido com o token do github packages fazendo com que sempre fosse publicado no GPR ao invez do NPM